### PR TITLE
Expand agent guides with code patterns and critical rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,100 +1,189 @@
 # GitHub Copilot Instructions — Linux Kernel Builder Suite
 
-## Project
+> Full agent guide: `AGENTS.md` (root). This file focuses on code generation patterns.
 
-Unified Linux kernel build suite (Bash + Arch/CachyOS PKGBUILDs). No Node.js, no Python runtime dependency for builds.
+## Project Snapshot
 
-## Key Commands
+- **What**: Unified Linux kernel build suite — Catgirl Edition, CachyMod, TKG integration, curated patches
+- **Language**: Bash (primary), Python (benchmark scraper only)
+- **Target**: Arch Linux / CachyOS (`pacman`, `makepkg`, PKGBUILD)
+- **Entry point**: `./kernel-builder.sh`
+- **No** Makefile, package.json, Cargo.toml, or pyproject.toml
+
+---
+
+## Critical Rules (Always Apply)
 
 ```bash
-# Main entry point
-./kernel-builder.sh [catgirl|cachymod|tkg|patches|fetch|help]
-
-# Build Catgirl Edition
-cd build/catgirl-edition && makepkg -scf --cleanbuild --skipchecksums
-
-# Build CachyMod (interactive)
-cd build/cachymod/6.18 && ../confmod.sh   # configure
-./build.sh <confname>                      # build
-
-# Fetch upstream patches
-./scripts/fetch.sh
-
-# Validate shell scripts
-bash -n script.sh
-shellcheck --enable=all script.sh
-
-# Test patch application
-patch -p1 --dry-run < 6.18/patch.patch
-```
-
-## Shell Script Conventions
-
-Always source the shared library — never duplicate helpers:
-```bash
+# REQUIRED at top of every new shell script — no exceptions
 #!/usr/bin/env bash
 # shellcheck enable=all shell=bash source-path=SCRIPTDIR external-sources=true
 # shellcheck source=./lib-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-common.sh"
 ```
 
-**Output functions** (from `scripts/lib-common.sh`):
-- `info "msg"` → green (success/progress)
-- `warn "msg"` → yellow (non-fatal)
-- `msg "msg"` → cyan (informational)
-- `die "msg"` → red + exit 1 (fatal)
+| Do | Don't |
+|----|-------|
+| `die "reason"` for fatal errors | `exit 1` bare |
+| `require_commands foo bar` to check deps | Silent missing-command failures |
+| `source lib-common.sh` for all helpers | Copy color defs or helper functions |
+| `add_cleanup "/tmp/dir"` for temp paths | Manual `rm` in ad-hoc traps |
+| `validate_kernel_dir "$KERNEL_DIR"` before kconfig ops | Assume the kernel dir exists |
+| `rg` for file/code search | `grep -r` or `find` |
+| `bash -n script.sh && shellcheck script.sh` before commit | Skipping lint |
+| `/usr/bin/env bash` shebang | `/bin/bash` shebang |
 
-**Error handling**:
+---
+
+## Output Functions
+
+Always use these from `scripts/lib-common.sh` — never `echo` directly for user-facing output:
+
 ```bash
-require_commands pacman makepkg   # check deps, die if missing
-validate_kernel_dir "$KERNEL_DIR" # validate kernel source
-die "reason"                      # fatal error, always prefer over bare exit 1
-add_cleanup "/tmp/tempdir"        # register for auto-cleanup on EXIT
+info  "Build complete"          # green  — success / progress
+warn  "ccache not found"        # yellow — non-fatal, continues
+msg   "Applying patches..."     # cyan   — informational / neutral
+die   "Kernel dir not found"    # red    — fatal, exits immediately
+debug "Loop iteration: $i"      # magenta — only shown when DEBUG=1
 ```
+
+---
 
 ## Naming
 
-- Functions: `snake_case` (lib funcs), `PascalCase` (kernel-builder.sh commands)
-- Constants: `UPPER_CASE`; locals: `lower_case`
-- PKGBUILD user vars: `_leading_underscore` with `": ${_var:=default}"` pattern
-- Patches: `descriptive-kebab-case.patch` or `<git-hash>.patch`
-- CachyMod configs: `<version>-<scheduler>.conf` (e.g., `618-bore.conf`)
+| Context | Convention | Example |
+|---------|-----------|---------|
+| Lib functions | `snake_case` | `validate_kernel_dir` |
+| `kernel-builder.sh` commands | `PascalCase` | `BuildCatgirl` |
+| Constants / exports | `UPPER_CASE` | `MAX_PARALLEL` |
+| Local variables | `lower_case` | `kdir` |
+| PKGBUILD user vars | `_leading_underscore` | `_cpusched` |
+| Patch files | `kebab-case.patch` or `<hash>.patch` | `bore-sched-6.18.patch` |
+| CachyMod configs | `<ver>-<sched>.conf` | `618-bore.conf` |
 
-## File Placement
+---
 
-| What | Where |
-|------|-------|
-| Shared bash utilities | `scripts/lib-common.sh` |
-| Kernel kconfig helpers | `scripts/lib-kernel-config.sh` |
-| Version-specific patches | `<version>/` (e.g., `6.18/`) |
-| PKGBUILD variants | `build/<name>/PKGBUILD` + `build/<name>/config` |
+## Where Things Go
+
+| What you're adding | Where it goes |
+|--------------------|---------------|
+| Shared bash helpers | `scripts/lib-common.sh` |
+| Kernel kconfig functions | `scripts/lib-kernel-config.sh` |
+| Patches for kernel 6.18 | `6.18/<name>.patch` + entry in `6.18/patches.txt` |
+| Patches for other versions | `<ver>/<name>.patch` + `<ver>/patches.txt` |
+| New PKGBUILD variant | `build/<name>/PKGBUILD` + `build/<name>/config` |
 | CachyMod patches | `build/cachymod/6.18/*.patch` |
+| Pre-made CachyMod configs | `build/cachymod/defconfigs/<ver>-<sched>.conf` |
 
-## PKGBUILD User Variables
+---
+
+## PKGBUILD Pattern
+
+All user-tunable variables use colon-expansion so they can be overridden from the environment:
 
 ```bash
-: "${_cpusched:=bore}"           # bore | eevdf | bmq | rt | rt-bore
-: "${_use_llvm_lto:=thin}"       # none | thin | full
-: "${_optimize:=O3}"             # O2 | O3 | Os | Ofast
-: "${_march:=native}"            # CPU target
-: "${_localmodcfg:=no}"          # yes = use modprobed-db
-: "${_makenconfig:=no}"          # yes = launch nconfig before build
+: "${_cpusched:=bore}"       # bore | eevdf | bmq | rt | rt-bore
+: "${_use_llvm_lto:=thin}"   # none | thin | full
+: "${_optimize:=O3}"         # O2 | O3 | Os | Ofast
+: "${_march:=native}"        # CPU target (native, x86-64, x86-64-v3, x86-64-v4)
+: "${_localmodcfg:=no}"      # yes = use modprobed-db for minimal kernel
+: "${_makenconfig:=no}"      # yes = pause for interactive nconfig
 ```
+
+---
+
+## Kconfig Helper Pattern
+
+All kernel config manipulation goes through `scripts/lib-kernel-config.sh`:
+
+```bash
+# Single option
+apply_my_feature(){ _apply_config "$1" -e MY_FEATURE -d CONFLICTING_OPT; }
+
+# Batch (preferred — fewer subprocess forks)
+apply_my_feature(){
+  _apply_config "$1" \
+    -e MY_FEATURE_A \
+    -e MY_FEATURE_B \
+    -d CONFLICTING_OPT
+}
+
+# Call site (compile.sh or PKGBUILD)
+apply_my_feature "$KERNEL_DIR"
+```
+
+---
+
+## Error Handling Pattern
+
+```bash
+# Dependency check — dies with helpful message if any are missing
+require_commands expac pacman makepkg curl
+
+# Kernel source validation
+validate_kernel_dir "$KERNEL_DIR"
+
+# Temp directory with auto-cleanup
+tmpdir=$(mktemp -d)
+add_cleanup "$tmpdir"          # cleaned up on EXIT/INT/TERM automatically
+```
+
+---
+
+## Parallel Download Pattern (fetch.sh style)
+
+Use a rolling job window — not `wait` on all at once:
+
+```bash
+declare -i running=0
+for url in "${urls[@]}"; do
+  curl -fsSL "$url" -o "${url##*/}" &
+  (( ++running >= MAX_PARALLEL )) && { wait -n; (( --running )); }
+done
+wait
+```
+
+---
+
+## Common Build Commands
+
+```bash
+# Catgirl Edition
+cd build/catgirl-edition && makepkg -scf --cleanbuild --skipchecksums
+
+# CachyMod
+cd build/cachymod/6.18
+../confmod.sh            # interactive wizard → ~/.config/cachymod/<name>.conf
+./build.sh <confname>    # build from saved config
+./build.sh list          # list saved configs
+
+# Docker multi-arch
+./docker-build.sh [generic|v3|v4]
+
+# Patch dry-run
+patch -p1 --dry-run < 6.18/some.patch
+
+# Syntax + lint
+bash -n scripts/fetch.sh
+shellcheck --enable=all scripts/fetch.sh
+```
+
+---
 
 ## CI/CD
 
-- **Lint**: `super-linter` on push/PR to main — covers shellcheck, markdownlint
-- **Build**: Tests `linux-cachyos` PKGBUILD with GCC and Clang on push to that path
-- **Fetch**: Manual dispatch only — runs `scripts/fetch.sh`
-- Actions use `actions/checkout@v6`, `actions/cache@v5`, `actions/upload-artifact@v7`
+| Workflow | Trigger | Action |
+|----------|---------|--------|
+| `build.yml` | Push to `linux-cachyos/PKGBUILD` or manual | Parallel GCC + Clang build; artifact upload |
+| `fetch.yml` | Manual `workflow_dispatch` | Runs `scripts/fetch.sh` |
 
-## Dependencies
+Build matrix: `_use_llvm_lto=none` (gcc) and `_use_llvm_lto=thin` (clang).
+Pinned action versions: `actions/checkout@v6`, `actions/cache@v5`, `actions/upload-artifact@v7`.
 
-`base-devel clang lld llvm gum fzf expac modprobed-db ccache`
+---
 
-## Do Not
+## Never Commit
 
-- Copy color definitions or helper functions — source `lib-common.sh`
-- Use bare `exit 1` — use `die "reason"`
-- Skip shellcheck directives at script top
-- Commit build artifacts (`src/`, `pkg/`, `*.pkg.tar.zst`, `*.tar.xz`)
+- `src/`, `pkg/`, `*.pkg.tar.zst`, `*.tar.xz`, `*.tar.zst` — build artifacts
+- Untracked `.config` changes from `make menuconfig` sessions
+- Hardcoded paths (use `$KERNEL_DIR`, `$SCRIPT_DIR`, `$HOME`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,25 @@
 
 > Canonical reference for AI coding agents (Claude, Gemini, Copilot, etc.).
 > Keep this file in sync with the codebase when making structural changes.
+> **Aliases**: `CLAUDE.md` and `GEMINI.md` are symlinks to this file.
+
+---
+
+## Agent Quick Start
+
+Before writing any code, read these files in order:
+
+1. `scripts/lib-common.sh` — shared library every script sources; understand its API before touching any script
+2. `scripts/lib-kernel-config.sh` — all kconfig manipulation goes here
+3. The specific script or PKGBUILD you are modifying
+
+**Key rules (never violate)**:
+- Always source `scripts/lib-common.sh`; never copy its helpers
+- Always use `die "msg"` for fatal errors; never `exit 1`
+- Always add shellcheck directives at the top of every new script
+- Never commit `src/`, `pkg/`, `*.pkg.tar.zst`, or `*.tar.xz` build artifacts
+- Run `bash -n <script.sh>` and `shellcheck` before committing any shell change
+- Use `rg` (ripgrep) for file/code discovery within the repo
 
 ---
 
@@ -19,65 +38,66 @@
 - `gum` — TUI dialogs for interactive scripts (CachyMod)
 - `fzf` — fuzzy finder for TKG installer menus
 - Docker (`pttrr/docker-makepkg`) — cross-arch kernel builds
-- GitHub Actions — CI/CD (lint, build, patch fetch)
+- GitHub Actions — CI/CD (build, patch fetch)
 
 ---
 
 ## Structure
 
 ```
-@Linux-Kernel-Patches/
-├── @kernel-builder.sh          # PRIMARY entry point — unified CLI for all operations
-├── @autofdo.sh                 # AutoFDO profile-guided optimization workflow
-├── @docker-build.sh            # Docker-based multi-arch kernel builds
-├── @cachyos-benchmarker.sh     # Mini benchmark suite (cpu/mem/io/codec)
-├── @benchmark_scraper.py       # Parse benchmark logs → HTML report + charts
-├── @srcinfo.sh                 # Regenerate .SRCINFO for all PKGBUILDs
+Linux-Kernel-Patches/
+├── kernel-builder.sh           # PRIMARY entry point — unified CLI for all operations
+├── autofdo.sh                  # AutoFDO profile-guided optimization workflow
+├── docker-build.sh             # Docker-based multi-arch kernel builds
+├── cachyos-benchmarker.sh      # Mini benchmark suite (cpu/mem/io/codec)
+├── custom-device-pollrates.sh  # USB/HID device polling rate configurator
+├── custom-device-pollrates.conf# udev rules config for poll rates
+├── custom-device-pollrates.service # systemd service for poll rate persistence
+├── benchmark_scraper.py        # Parse benchmark logs → HTML report + charts
+├── srcinfo.sh                  # Regenerate .SRCINFO for all PKGBUILDs
 │
-├── @scripts/
-│   ├── @lib-common.sh          # SHARED LIBRARY — source this in all scripts
-│   ├── @lib-kernel-config.sh   # Kernel kconfig helper functions (apply_*_opts)
-│   ├── @fetch.sh               # Parallel patch fetching from upstream lists
-│   ├── @compile.sh             # Kernel compilation with modprobed-db + xconfig
-│   ├── @tkg-installer          # TKG/Frogminer package TUI (linux/nvidia/mesa/wine/proton)
-│   ├── @install-tkg.sh         # Install tkg-installer to system
-│   └── @utils/
+├── scripts/
+│   ├── lib-common.sh           # SHARED LIBRARY — source this in ALL scripts
+│   ├── lib-kernel-config.sh    # Kernel kconfig helpers (apply_*_opts)
+│   ├── fetch.sh                # Parallel patch fetching from upstream lists
+│   ├── compile.sh              # Kernel compilation with modprobed-db + xconfig
+│   ├── tkg-installer           # TKG/Frogminer package TUI (linux/nvidia/mesa/wine/proton)
+│   ├── install-tkg.sh          # Install tkg-installer to system
+│   └── utils/
 │       ├── sort-modprobed-dbs  # Merge/sort modprobed-db files
 │       └── zramswap            # ZRAM swap configuration
 │
-├── @build/
-│   ├── @catgirl-edition/       # Catgirl Edition — aggressive perf kernel
-│   │   ├── @PKGBUILD           # PRIMARY build file; all tuning vars here
-│   │   ├── @config             # Base kernel .config (~289KB, ~8000 options)
-│   │   └── @patches/           # Build-time patches (Clear Linux patchset)
-│   ├── @cachymod/              # CachyMod — interactive CachyOS kernel builder
-│   │   ├── @confmod.sh         # Interactive config wizard (requires gum)
-│   │   ├── @uninstall.sh       # Remove installed cachymod kernels
-│   │   ├── @defconfigs/        # Pre-made .conf files (618-bore, 618-bmq, etc.)
-│   │   └── @6.18/              # Per-version build directory
-│   │       ├── @PKGBUILD       # CachyMod PKGBUILD
-│   │       ├── @build.sh       # Build from saved config name
-│   │       ├── @config.sh      # Config helper (wraps scripts/lib-kernel-config.sh)
-│   │       ├── @config         # Base kernel config
+├── build/
+│   ├── catgirl-edition/        # Catgirl Edition — aggressive perf kernel
+│   │   ├── PKGBUILD            # PRIMARY build file; all tuning vars here
+│   │   ├── config              # Base kernel .config (~289KB, ~8000 options)
+│   │   └── patches/            # Build-time patches (Clear Linux patchset)
+│   ├── cachymod/               # CachyMod — interactive CachyOS kernel builder
+│   │   ├── confmod.sh          # Interactive config wizard (requires gum)
+│   │   ├── uninstall.sh        # Remove installed cachymod kernels
+│   │   ├── defconfigs/         # Pre-made .conf files (618-bore, 618-bmq, etc.)
+│   │   └── 6.18/               # Per-version build directory
+│   │       ├── PKGBUILD        # CachyMod PKGBUILD
+│   │       ├── build.sh        # Build from saved config name
+│   │       ├── config.sh       # Config helper (wraps scripts/lib-kernel-config.sh)
+│   │       ├── config          # Base kernel config
 │   │       └── *.patch         # Scheduler and feature patches
-│   ├── @linux-cachyos/         # Upstream CachyOS kernel PKGBUILD
-│   ├── @linux-cachyos-bore/    # CachyOS with BORE scheduler
-│   ├── @linux-cachyos-rc/      # CachyOS release-candidate kernel
-│   └── @linux-cachyos-server/  # CachyOS server-optimized kernel
+│   ├── linux-cachyos/          # Upstream CachyOS kernel PKGBUILD
+│   ├── linux-cachyos-bore/     # CachyOS with BORE scheduler
+│   └── linux-cachyos-rc/       # CachyOS release-candidate kernel
 │
-├── @6.12/ @6.16/ @6.17/ @6.18/ @6.19/   # Patch collections per kernel version
+├── 6.12/ 6.18/ 6.19/           # Patch collections per kernel version
 │   ├── patches.txt             # Patch inventory / fetch list
 │   └── *.patch                 # Individual patch files
 │
-├── @docs/
+├── docs/
 │   ├── BUILD_GUIDE.md          # Comprehensive build guide
 │   ├── PATCH_SOURCES.md        # Upstream patch source references
 │   └── REFACTORING.md          # Refactoring history / design decisions
 │
-└── @.github/
+└── .github/
     ├── workflows/fetch.yml     # Trigger: manual — runs scripts/fetch.sh
-    ├── workflows/build.yml     # Trigger: push to linux-cachyos/PKGBUILD — builds GCC+Clang
-    └── workflows/super-linter.yml  # Trigger: push/PR to main — lints all code
+    └── workflows/build.yml     # Trigger: push to linux-cachyos/PKGBUILD — builds GCC+Clang
 ```
 
 ---
@@ -189,7 +209,8 @@ All scripts follow this pattern — **read `scripts/lib-common.sh` before writin
 # shellcheck source=./lib-common.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib-common.sh"
 
-# Strict mode (already set by lib-common.sh, but replicate in standalone scripts)
+# Strict mode is already set by lib-common.sh; only add below in standalone scripts
+# that may run without sourcing it:
 set -euo pipefail
 shopt -s nullglob globstar
 export LC_ALL=C
@@ -198,13 +219,13 @@ IFS=$'\n\t'
 
 ### Output Functions (from lib-common.sh)
 
-| Function | Color  | Use for                        |
-|----------|--------|-------------------------------|
-| `info`   | green  | Success / progress messages   |
-| `warn`   | yellow | Non-fatal warnings            |
-| `msg`    | cyan   | Informational / neutral       |
-| `die`    | red    | Fatal errors (exits)          |
-| `debug`  | magenta| Debug only when `DEBUG=1`     |
+| Function | Color   | Use for                       |
+|----------|---------|-------------------------------|
+| `info`   | green   | Success / progress messages   |
+| `warn`   | yellow  | Non-fatal warnings            |
+| `msg`    | cyan    | Informational / neutral       |
+| `die`    | red     | Fatal errors (exits)          |
+| `debug`  | magenta | Debug only when `DEBUG=1`     |
 
 ### Naming Conventions
 
@@ -265,20 +286,20 @@ s=${BASH_SOURCE[0]}; [[ $s != /* ]] && s=$PWD/$s; cd -P -- "${s%/*}"
 
 ## Dependencies
 
-| Dependency     | Purpose                                        | Required by              |
-|----------------|------------------------------------------------|--------------------------|
-| `base-devel`   | makepkg, gcc, etc.                             | All PKGBUILDs            |
-| `clang` + `lld`+ `llvm` | LLVM toolchain for LTO builds         | catgirl-edition, cachymod|
-| `gum`          | TUI dialogs for interactive config wizard       | `build/cachymod/confmod.sh` |
-| `fzf`          | Fuzzy finder menus                              | `scripts/tkg-installer`  |
-| `expac`        | Query pacman package info                       | `kernel-builder.sh`      |
-| `modprobed-db` | Track loaded modules → minimal kernel config   | `scripts/compile.sh`, PKGBUILDs |
-| `ccache`       | Compiler cache (speeds up rebuilds)             | All PKGBUILDs (optional) |
-| `namcap`       | PKGBUILD validation (optional)                  | CI/local dev             |
-| `Docker`       | Cross-arch kernel builds                        | `docker-build.sh`        |
-| `perf`         | CPU profiling for AutoFDO                       | `autofdo.sh`             |
-| `sysbench` / `stress-ng` | Performance and stability testing     | Post-install validation  |
-| `numpy` + `matplotlib` | Python benchmark report generation    | `benchmark_scraper.py`   |
+| Dependency               | Purpose                                      | Required by                          |
+|--------------------------|----------------------------------------------|--------------------------------------|
+| `base-devel`             | makepkg, gcc, etc.                           | All PKGBUILDs                        |
+| `clang` + `lld` + `llvm` | LLVM toolchain for LTO builds                | catgirl-edition, cachymod            |
+| `gum`                    | TUI dialogs for interactive config wizard    | `build/cachymod/confmod.sh`          |
+| `fzf`                    | Fuzzy finder menus                           | `scripts/tkg-installer`              |
+| `expac`                  | Query pacman package info                    | `kernel-builder.sh`                  |
+| `modprobed-db`           | Track loaded modules → minimal kernel config | `scripts/compile.sh`, PKGBUILDs      |
+| `ccache`                 | Compiler cache (speeds up rebuilds)          | All PKGBUILDs (optional)             |
+| `namcap`                 | PKGBUILD validation (optional)               | CI/local dev                         |
+| `Docker`                 | Cross-arch kernel builds                     | `docker-build.sh`                    |
+| `perf`                   | CPU profiling for AutoFDO                    | `autofdo.sh`                         |
+| `sysbench` / `stress-ng` | Performance and stability testing            | Post-install validation              |
+| `numpy` + `matplotlib`   | Python benchmark report generation           | `benchmark_scraper.py`               |
 
 ---
 
@@ -392,11 +413,10 @@ bash -n kernel-builder.sh
 
 ### Workflows
 
-| Workflow | File | Trigger | What it does |
-|----------|------|---------|--------------|
-| **Fetch** | `.github/workflows/fetch.yml` | `workflow_dispatch` (manual) | Runs `scripts/fetch.sh` to download latest patches |
-| **Build** | `.github/workflows/build.yml` | Push to `linux-cachyos/PKGBUILD` or `workflow_dispatch` | Builds `linux-cachyos` with GCC and Clang in parallel; uploads `.pkg.tar.zst` as artifact |
-| **Lint** | `.github/workflows/super-linter.yml` | Push/PR to `main` | Runs `super-linter` on changed files (shellcheck, markdownlint, etc.) |
+| Workflow  | File                           | Trigger                                    | What it does                                                                     |
+|-----------|--------------------------------|--------------------------------------------|----------------------------------------------------------------------------------|
+| **Fetch** | `.github/workflows/fetch.yml`  | `workflow_dispatch` (manual)               | Runs `scripts/fetch.sh` to download latest patches                               |
+| **Build** | `.github/workflows/build.yml`  | Push to `linux-cachyos/PKGBUILD` or manual | Builds `linux-cachyos` with GCC and Clang in parallel; uploads `.pkg.tar.zst`   |
 
 ### Build Matrix
 
@@ -438,17 +458,18 @@ jobs:
 
 ## Tool Preferences
 
-| Category       | Tool                    | Notes                                          |
-|----------------|-------------------------|------------------------------------------------|
-| Shell          | Bash (4+)               | `#!/usr/bin/env bash`, not `/bin/bash`         |
-| Linter         | shellcheck              | `enable=all`, directives at top of each file  |
-| Package manager| pacman / makepkg        | Arch/CachyOS only                             |
-| Compiler       | Clang/LLVM (preferred)  | GCC as fallback; set via `_use_llvm_lto`      |
-| TUI            | gum (confmod), fzf (tkg)| Not interchangeable                           |
-| Profiler       | perf (AutoFDO)          | `autofdo.sh` workflow                         |
-| Formatter      | None enforced           | Follow surrounding code style                 |
-| Python         | System python3          | Only for `benchmark_scraper.py`               |
-| Docker image   | `pttrr/docker-makepkg`  | For cross-arch builds in `docker-build.sh`    |
+| Category        | Tool                     | Notes                                         |
+|-----------------|--------------------------|-----------------------------------------------|
+| Shell           | Bash (4+)                | `#!/usr/bin/env bash`, not `/bin/bash`        |
+| Linter          | shellcheck               | `enable=all`, directives at top of each file  |
+| Package manager | pacman / makepkg         | Arch/CachyOS only                             |
+| Compiler        | Clang/LLVM (preferred)   | GCC as fallback; set via `_use_llvm_lto`      |
+| TUI             | gum (confmod), fzf (tkg) | Not interchangeable                           |
+| Profiler        | perf (AutoFDO)           | `autofdo.sh` workflow                         |
+| Formatter       | None enforced            | Follow surrounding code style                 |
+| Python          | System python3           | Only for `benchmark_scraper.py`               |
+| Docker image    | `pttrr/docker-makepkg`   | For cross-arch builds in `docker-build.sh`    |
+| File search     | `rg` (ripgrep)           | Preferred over `grep`/`find` for discovery    |
 
 ---
 
@@ -499,4 +520,4 @@ sudo pacman -S modprobed-db && sudo modprobed-db store
 
 ---
 
-*This file is the canonical AI agent guide. `CLAUDE.md` and `GEMINI.md` are aliases for this file.*
+*This file is the canonical AI agent guide. `CLAUDE.md` and `GEMINI.md` are symlinks to this file.*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Significantly expanded the GitHub Copilot instructions and agent guides to provide comprehensive code generation patterns, critical rules, and structural reference for AI coding agents. This ensures consistency across all future contributions and reduces ambiguity in code style and organization.

## Key Changes

- **copilot-instructions.md**: Restructured from brief command reference to detailed guide including:
  - Critical rules table (shellcheck directives, error handling, naming conventions)
  - Output functions reference with color coding
  - File placement guide for patches, PKGBUILDs, and helpers
  - PKGBUILD variable pattern with colon-expansion defaults
  - Kconfig helper pattern for kernel config manipulation
  - Error handling patterns (dependency checks, validation, cleanup)
  - Parallel download pattern for fetch operations
  - Common build commands reference
  - CI/CD workflow matrix
  - Explicit "Never Commit" section for build artifacts

- **AGENTS.md**: Enhanced with:
  - Agent Quick Start section directing to key files in reading order
  - Key rules callout (sourcing lib-common.sh, die vs exit, shellcheck, artifact exclusions, linting, ripgrep usage)
  - Updated file structure tree (removed `@` prefixes for clarity)
  - Added new tools: `custom-device-pollrates.*` files and `srcinfo.sh`
  - Clarified strict mode documentation
  - Improved output functions table formatting
  - Enhanced dependencies table with better alignment
  - Added `rg` (ripgrep) to tool preferences as preferred search tool
  - Updated workflow table to remove super-linter reference
  - Clarified symlink relationship in footer

- **GEMINI.md**: Created as symlink to AGENTS.md (matching CLAUDE.md pattern)

## Notable Implementation Details

- Introduced structured tables for quick reference (naming conventions, file placement, output functions, dependencies, workflows)
- Emphasized `scripts/lib-common.sh` as the canonical source for shared helpers—never duplicate
- Standardized error handling: `die "msg"` for fatal errors, `require_commands` for dependency checks, `add_cleanup` for temp paths
- Documented PKGBUILD colon-expansion pattern for environment variable overrides
- Clarified kconfig manipulation must go through `scripts/lib-kernel-config.sh`
- Added explicit guidance on parallel job windows for downloads (rolling window vs. `wait` all)
- Removed references to super-linter workflow (no longer active)

https://claude.ai/code/session_01QGk85FviiHUyytCprFC2ba